### PR TITLE
Docs: Add docstrings to modules and core components

### DIFF
--- a/pysible/core/app.py
+++ b/pysible/core/app.py
@@ -15,7 +15,25 @@ from pysible.utils.misc_utils import delete_tmp_dir
 
 
 class PysibleApp:
+    """
+    Main application class for Pysible.
+
+    This class is responsible for initializing the application, managing the
+    user interface (displaying tasks and getting user input), and coordinating
+    the execution of selected tasks.
+    """
     def __init__(self):
+        """
+        Initializes the PysibleApp instance.
+
+        Sets up the console, task manager, and a temporary directory for
+        application use. It also clears the console screen upon initialization.
+
+        Side Effects:
+            - Deletes any existing temporary directory used by Pysible.
+            - Creates a new temporary directory.
+            - Clears the console screen.
+        """
         self.console: Console = Console()
         self.task_manager: TaskManager = TaskManager()
         delete_tmp_dir()
@@ -23,9 +41,36 @@ class PysibleApp:
         _ = os.system("clear")
 
     def _get_user_input(self) -> str:
+        """
+        Prompts the user for input and returns the stripped string.
+
+        Displays the Pysible command prompt and waits for the user to enter
+        a command or task selection.
+
+        Returns:
+            The user's input string, with leading/trailing whitespace removed.
+        """
         return Prompt.ask("[bold blue]Pysible ~> [/bold blue]").strip()
 
-    def _handel_user_input(self, choice: str):
+    def _handle_user_input(self, choice: str):
+        """
+        Processes the user's input to determine which tasks to execute.
+
+        Parses the user's choice, which can be a special command (like '00'
+        for all tasks, '100' for system tasks, '200' for software tasks,
+        or 'q'/'exit'/'quit' to exit) or a list of task numbers.
+        Selected tasks are then executed.
+
+        Args:
+            choice: The user's input string.
+
+        Side Effects:
+            - Executes tasks based on the user's selection. Each task can have
+              its own side effects (e.g., installing software, modifying files).
+            - Prints informational messages or error messages to the console.
+            - Exits the application if the user chooses to quit.
+            - Deletes the temporary directory upon exit.
+        """
         tasks_to_execute: list[Task] = []
         match choice:
             case "00":
@@ -64,6 +109,16 @@ class PysibleApp:
             task.execute()
 
     def _render_menu_table(self):
+        """
+        Renders and displays a table of available tasks to the console.
+
+        The table categorizes tasks by section (e.g., System, Software) and
+        displays their assigned numbers and names. It also shows options for
+        running all tasks or all tasks within a specific section.
+
+        Side Effects:
+            - Prints a formatted table to the console.
+        """
         sections = [section.value for section in Sections]
         table = Table(
             box=SIMPLE_HEAVY,
@@ -105,11 +160,30 @@ class PysibleApp:
         self.console.print(table)
 
     def exit_handler(self) -> None:
+        """
+        Handles application exit by cleaning up resources.
+
+        Currently, this involves deleting the temporary directory used by Pysible.
+
+        Side Effects:
+            - Deletes the Pysible temporary directory.
+        """
         delete_tmp_dir()
 
     def run(self):
+        """
+        Starts the main application loop.
+
+        Continuously displays the task menu, gets user input, and handles
+        the input until the user chooses to exit.
+
+        Side Effects:
+            - Enters an infinite loop that can only be broken by user choosing
+              to exit or by an unhandled exception.
+            - Calls other methods that print to console and execute tasks.
+        """
         self.console.print("[bold green]Lets Roll...[/bold green]")
         while True:
             self._render_menu_table()
             user_choice = self._get_user_input()
-            self._handel_user_input(user_choice)
+            self._handle_user_input(user_choice)

--- a/pysible/core/task.py
+++ b/pysible/core/task.py
@@ -3,6 +3,13 @@ from pysible.utils.log_utils import Logger
 
 
 class Task:
+    """
+    Represents a single executable task within the Pysible application.
+
+    Each task has a number for identification, a name, an action function
+    that it performs, a section it belongs to, and optional parameters
+    for the action function.
+    """
     def __init__(
         self,
         number: int,
@@ -11,6 +18,19 @@ class Task:
         section: str,
         params: dict[str, str] | None = None,
     ):
+        """
+        Initializes a Task instance.
+
+        Args:
+            number: The unique number identifying the task.
+            name: The human-readable name of the task.
+            action_function: The function to be executed when the task runs.
+            section: The section name (e.g., "SYSTEM", "SOFTWARE") the task
+                     belongs to.
+            params: An optional dictionary of parameters to be passed to the
+                    `action_function` when it's executed. Defaults to an
+                    empty dictionary if None.
+        """
         self.number: int = number
         self.name: str = name
         self.action_function = action_function
@@ -18,6 +38,19 @@ class Task:
         self.params: dict[str, str] | None = params if params is not None else {}
 
     def execute(self) -> None:
+        """
+        Executes the task's action_function with its defined parameters.
+
+        It handles potential `TaskFailedException` raised by the action
+        function and logs success or failure messages accordingly. It also
+        catches any other unexpected exceptions.
+
+        Side Effects:
+            - Executes the `action_function`, which can have various side effects
+              depending on its implementation (e.g., file system changes,
+              network requests, command execution).
+            - Logs success or failure messages to the console via `Logger`.
+        """
         try:
             self.action_function(**self.params)
             Logger.success(f"Task '{self.name}' completed successfully.")

--- a/pysible/core/task_manager.py
+++ b/pysible/core/task_manager.py
@@ -7,11 +7,37 @@ from pysible.utils.log_utils import Logger
 
 
 class TaskManager:
+    """
+    Manages the discovery, registration, and retrieval of tasks.
+
+    This class is responsible for loading task modules, registering tasks
+    that are decorated with `@task_plugin`, and providing methods to access
+    these tasks by number, section, or to get all available tasks.
+    """
     def __init__(self):
+        """
+        Initializes the TaskManager instance.
+
+        It creates an empty dictionary to store tasks and then calls
+        `_register_tasks` to discover and load all available tasks from
+        the `pysible.modules` package.
+        """
         self.tasks: dict[int, Task] = {}
         self._register_tasks()
 
     def _load_modules(self):
+        """
+        Dynamically imports all modules within the `pysible.modules` package.
+
+        This is a prerequisite for task registration, as tasks are typically
+        defined within these modules and registered upon module import via
+        decorators.
+
+        Side Effects:
+            - Imports Python modules. This can lead to execution of code at the
+              module level within each imported module.
+            - Logs a warning if a module cannot be imported.
+        """
         import pysible.modules
 
         package = pysible.modules
@@ -24,6 +50,19 @@ class TaskManager:
                 Logger.warn(f"Could not import module {module_name}: {e}")
 
     def _register_tasks(self):
+        """
+        Registers tasks found in the application settings.
+
+        This method first ensures all modules are loaded by calling `_load_modules`.
+        It then iterates through tasks stored in `settings.REGISTERED_TASKS`
+        (which are populated by the `@task_plugin` decorator during module import)
+        and adds them to the `self.tasks` dictionary.
+
+        Side Effects:
+            - Populates the `self.tasks` dictionary.
+            - Logs a warning if a task number is duplicated, overwriting the
+              previous task with the new one.
+        """
         self._load_modules()
 
         for task in settings.REGISTERED_TASKS:
@@ -34,10 +73,37 @@ class TaskManager:
             self.tasks[task.number] = task
 
     def get_task(self, task_number: int) -> Task | None:
+        """
+        Retrieves a specific task by its number.
+
+        Args:
+            task_number: The unique number of the task to retrieve.
+
+        Returns:
+            The `Task` object if found, otherwise `None`.
+        """
         return self.tasks.get(task_number)
 
     def get_all_tasks(self) -> list[Task]:
+        """
+        Retrieves a list of all registered tasks.
+
+        Returns:
+            A list containing all `Task` objects, sorted by task number
+            (due to dict insertion order in modern Python, but not guaranteed
+            for older versions).
+        """
         return list(self.tasks.values())
 
     def get_tasks_by_section(self, section: Sections) -> list[Task]:
+        """
+        Retrieves a list of tasks belonging to a specific section.
+
+        Args:
+            section: An enum member of `pysible.config.settings.Sections`
+                     representing the section to filter by (e.g., Sections.SYSTEM).
+
+        Returns:
+            A list of `Task` objects that belong to the specified section.
+        """
         return [task for task in self.tasks.values() if task.section == section.value]

--- a/pysible/modules/buildkit.py
+++ b/pysible/modules/buildkit.py
@@ -11,6 +11,25 @@ from pysible.utils.misc_utils import create_tmp_dir
 
 @task_plugin(name="Install Buildkit", section=Sections.SOFTWARE)
 def install_buildkit() -> None:
+    """Installs Buildkit, a toolkit for converting source code to build artifacts.
+
+    This function performs the following steps:
+    1. Fetches the latest version of Buildkit from the moby/buildkit GitHub repository.
+    2. Constructs the download URL for the Linux amd64 binary.
+    3. Creates a temporary directory for the download.
+    4. Downloads the Buildkit tarball.
+    5. Extracts the tarball.
+    6. Copies the 'buildkitd' and 'buildctl' binaries to /usr/local/bin.
+    7. Sets execute permissions on the binaries.
+    8. Copies the systemd service file for Buildkit to /etc/systemd/system.
+    9. Copies the Buildkit daemon configuration file to /etc/buildkit.
+    10. Logs success or failure messages.
+
+    Raises:
+        TaskFailedException: If any step in the installation process fails,
+                             either due to a shell command error or any other
+                             unexpected exception.
+    """
     version = net.get_latest_version_from_github(
         repo_owner="moby", repo_name="buildkit"
     )

--- a/pysible/modules/dnf.py
+++ b/pysible/modules/dnf.py
@@ -5,6 +5,24 @@ from pysible.core.task_plugin_decorator import task_plugin
 
 @task_plugin(name="Install Core DNF Packages", section=Sections.SOFTWARE)
 def install_dnf_packages():
+    """Installs a predefined list of core software packages using DNF.
+
+    This function defines a set of essential packages and uses the
+    `pysible.utils.package_utils.install` utility to install them via
+    the DNF package manager. The list includes a variety of tools
+    such as development tools, system utilities, and applications.
+
+    Side Effects:
+        - Installs system packages using DNF. This requires sudo privileges
+          and can modify the system state.
+        - Logs the installation progress and results.
+
+    Raises:
+        TaskFailedException: If the `packages.install` call fails for any reason
+                             (e.g., DNF not found, package not found, network issues).
+                             The specific exception is caught and re-raised by the
+                             `packages.install` utility.
+    """
     package_list = {
         "code",
         "helm",

--- a/pysible/modules/dotfiles.py
+++ b/pysible/modules/dotfiles.py
@@ -10,6 +10,21 @@ from pysible.utils.net_utils import git_clone
 
 
 def _run_dotfiles_install_script(dotfiles_repo_path: str) -> None:
+    """Executes the install script located in the dotfiles repository.
+
+    Args:
+        dotfiles_repo_path: The local file system path to the cloned dotfiles
+                            repository.
+
+    Side Effects:
+        - Runs a shell script (`install.sh`) which can modify system
+          configuration and install files.
+        - Logs an informational message upon successful execution.
+
+    Raises:
+        sh.ErrorReturnCode: If the `install.sh` script exits with a non-zero
+                            status code.
+    """
     install_script_path = path.join(dotfiles_repo_path, "install.sh")
     bash = sh.Command("bash")
     _ = bash(install_script_path, _cwd=dotfiles_repo_path)
@@ -21,6 +36,28 @@ def _run_dotfiles_install_script(dotfiles_repo_path: str) -> None:
     section=Sections.SYSTEM,
 )
 def install_dotfiles():
+    """Clones a dotfiles repository and runs its installation script.
+
+    This function performs the following steps:
+    1. Defines the target directory for the dotfiles repository and its URL.
+    2. Clones the dotfiles repository from GitHub using `git_clone`.
+    3. Calls `_run_dotfiles_install_script` to execute the `install.sh`
+       script within the cloned repository.
+    4. Logs a success message if all steps complete without error.
+
+    Side Effects:
+        - Creates a directory for the dotfiles if it doesn't exist.
+        - Clones a Git repository into the specified directory.
+        - Executes an external shell script which can modify user and system
+          configurations.
+        - Logs progress and outcome.
+
+    Raises:
+        TaskFailedException: If `git_clone` fails (e.g., network issue,
+                             repository not found, git not installed), or if the
+                             dotfiles installation script returns an error, or if
+                             any other unexpected exception occurs.
+    """
     dotfile_dir = f"{settings.HOME_DIR}/DEV/dotfiles"
     repo_url = "https://github.com/KJone1/dotfiles.git"
 

--- a/pysible/modules/flatpak.py
+++ b/pysible/modules/flatpak.py
@@ -5,6 +5,30 @@ from pysible.core.task_plugin_decorator import task_plugin
 
 @task_plugin(name="Install Flatpak Packages", section=Sections.SOFTWARE)
 def install_flatpak_packages():
+    """Installs a predefined list of Flatpak applications.
+
+    This function performs the following steps:
+    1. Defines a set of Flatpak application IDs.
+    2. Ensures the Flathub repository is set up using
+       `pysible.utils.package_utils.setup_flatpak_repo`.
+    3. Installs the defined Flatpak applications using
+       `pysible.utils.package_utils.install` with the 'flatpak'
+       package manager.
+
+    Side Effects:
+        - May add the Flathub remote repository if it's not already configured.
+        - Installs Flatpak applications system-wide or user-wide, depending
+          on the Flatpak setup. This requires appropriate permissions and can
+          modify the system state.
+        - Logs the installation progress and results.
+
+    Raises:
+        TaskFailedException: If `setup_flatpak_repo` or `packages.install`
+                             fails for any reason (e.g., Flatpak not found,
+                             network issues, package not found). The specific
+                             exception is caught and re-raised by the utility
+                             functions.
+    """
     package_list = {
         "com.discordapp.Discord",
         "io.github.flattool.Warehouse",

--- a/pysible/modules/k0s.py
+++ b/pysible/modules/k0s.py
@@ -8,6 +8,27 @@ from pysible.utils.log_utils import Logger
 
 @task_plugin(name="Install k0s", section=Sections.SOFTWARE)
 def install_k0s() -> None:
+    """Installs k0s, a lightweight Kubernetes distribution.
+
+    This function performs the following steps:
+    1. Downloads and executes the official k0s installation script using curl
+       and sh. This script typically installs the k0s binary.
+    2. Runs the k0s command to install a single-node controller, forcing
+       the installation if a previous one exists.
+    3. Logs informational messages at the start of the process.
+
+    Side Effects:
+        - Downloads and executes an external script from the internet.
+        - Installs k0s binaries and related files onto the system.
+        - May create or modify system services for k0s.
+        - Requires sudo privileges for installation.
+        - Logs the start of the installation.
+
+    Raises:
+        TaskFailedException: If any of the shell commands (curl, k0s install)
+                             fail with a non-zero exit code, or if any other
+                             unexpected exception occurs during the process.
+    """
     Logger.info("Starting to install k0s...")
     try:
         sh.bash("curl -sSLf https://get.k0s.sh | sudo sh")

--- a/pysible/modules/k9s.py
+++ b/pysible/modules/k9s.py
@@ -12,6 +12,31 @@ from pysible.utils.misc_utils import create_tmp_dir
 
 @task_plugin(name="Install k9s", section=Sections.SOFTWARE)
 def install_k9s():
+    """Installs k9s, a terminal-based UI for Kubernetes clusters.
+
+    This function performs the following steps:
+    1. Fetches the latest version tag of k9s from the "derailed/k9s"
+       GitHub repository.
+    2. Constructs the download URL for the Linux amd64 RPM package.
+    3. Creates a temporary directory for the download.
+    4. Downloads the k9s RPM package.
+    5. Installs the RPM package using `pysible.utils.package_utils.install_package`.
+    6. Logs success or failure messages.
+
+    Side Effects:
+        - Creates a temporary directory.
+        - Downloads a file from the internet.
+        - Installs an RPM package, which modifies the system and requires
+          sudo privileges.
+        - Logs information about the process.
+
+    Raises:
+        TaskFailedException: If any step in the process fails. This includes
+                             errors during version fetching (network issues, API
+                             changes), file download, RPM installation (DNF errors,
+                             command not found), or any other unexpected Python
+                             exceptions (OSError, ValueError, KeyError).
+    """
     try:
         version = net.get_latest_version_from_github(
             repo_owner="derailed", repo_name="k9s"

--- a/pysible/modules/moonlander.py
+++ b/pysible/modules/moonlander.py
@@ -7,6 +7,26 @@ from pysible.utils.log_utils import Logger
 
 @task_plugin(name="Setup Moonlander keyboard", section=Sections.SYSTEM)
 def setup_moonlander() -> None:
+    """Sets up udev rules for the ZSA Moonlander keyboard.
+
+    This function copies a predefined udev rules file (`50-zsa.rules`) from
+    the application's resources to the system's udev rules directory
+    (`/etc/udev/rules.d/`). This allows the system to correctly recognize
+    and configure the Moonlander keyboard.
+
+    Side Effects:
+        - Copies a file to a system directory (`/etc/udev/rules.d/`), which
+          typically requires sudo privileges.
+        - May trigger udev to reload rules, or a manual reload might be needed
+          for changes to take effect.
+        - Logs a success message or raises an exception on failure.
+
+    Raises:
+        TaskFailedException: If the `copy_resource` operation fails for any
+                             reason (e.g., file not found in resources,
+                             permission denied to write to the destination,
+                             or other I/O errors).
+    """
     udev_rules = "50-zsa.rules"
     rules_dir = "/etc/udev/rules.d/"
     try:

--- a/pysible/modules/nerdctl.py
+++ b/pysible/modules/nerdctl.py
@@ -12,6 +12,36 @@ from pysible.utils.misc_utils import create_tmp_dir
 
 @task_plugin(name="Install nerdctl", section=Sections.SOFTWARE)
 def install_nerdctl() -> None:
+    """Installs nerdctl, a Docker-compatible CLI for containerd.
+
+    This function performs the following steps:
+    1. Fetches the latest version of nerdctl from the "containerd/nerdctl"
+       GitHub repository.
+    2. Constructs the download URL for the Linux amd64 tarball.
+    3. Creates a temporary directory for the download.
+    4. Downloads the nerdctl tarball.
+    5. Extracts the tarball into the temporary directory.
+    6. Copies the 'nerdctl' binary to /usr/local/bin.
+    7. Copies a default configuration file (`nerdctl.toml`) from resources
+       to /etc/nerdctl/nerdctl.toml.
+    8. Sets execute permissions ('555') on the nerdctl binary.
+    9. Logs success or various failure messages.
+
+    Side Effects:
+        - Creates a temporary directory.
+        - Downloads a file from the internet.
+        - Extracts a tarball to the temporary directory.
+        - Copies files to system directories (/usr/local/bin, /etc/nerdctl),
+          which typically requires sudo privileges.
+        - Modifies file permissions, typically requiring sudo privileges.
+        - Logs information about the process.
+
+    Raises:
+        TaskFailedException: If any step in the process fails. This includes
+                             errors during version fetching, download (HTTPError),
+                             file operations (OSError, ValueError, sh.ErrorReturnCode,
+                             FileNotFoundError), or any other unexpected Python exception.
+    """
     version = net.get_latest_version_from_github(
         repo_owner="containerd", repo_name="nerdctl"
     )

--- a/pysible/modules/sddm.py
+++ b/pysible/modules/sddm.py
@@ -10,7 +10,26 @@ from pysible.utils.net_utils import git_clone
 
 
 def _update_sddm_theme(config_file_path: str, theme_name: str) -> None:
-    """Updates the SDDM theme in the KDE settings configuration file"""
+    """Updates the SDDM theme in a given SDDM configuration file.
+
+    It reads the specified configuration file, searches for a line starting
+    with "Current=", and replaces its value with the provided `theme_name`.
+    Other lines are written back unchanged.
+
+    Args:
+        config_file_path: The absolute path to the SDDM configuration file
+                          (e.g., "/etc/sddm.conf.d/kde_settings.conf").
+        theme_name: The name of the SDDM theme to set as current.
+
+    Side Effects:
+        - Reads from and writes to the specified `config_file_path`. This
+          typically requires sudo privileges if the file is a system file.
+
+    Raises:
+        FileNotFoundError: If `config_file_path` does not exist.
+        IOError: If there are issues reading from or writing to the file.
+        PermissionError: If the user lacks necessary permissions for the file.
+    """
     with open(config_file_path, "r") as f:
         lines = f.readlines()
     with open(config_file_path, "w") as f:
@@ -23,7 +42,30 @@ def _update_sddm_theme(config_file_path: str, theme_name: str) -> None:
 
 @task_plugin(name="Setup SDDM theme", section=Sections.SYSTEM)
 def setup_sddm() -> None:
+    """Installs and applies a specific SDDM theme.
 
+    This function performs the following steps:
+    1. Defines the URL for a Git repository containing an SDDM theme and
+       the local destination path for cloning.
+    2. Defines the path to the SDDM configuration file and the theme name.
+    3. Clones the SDDM theme repository into the system's SDDM themes directory
+       (typically requires sudo privileges).
+    4. Calls `_update_sddm_theme` to set the cloned theme as the current
+       theme in the SDDM configuration file.
+
+    Side Effects:
+        - Clones a Git repository into a system directory
+          (`/usr/share/sddm/themes/`), requiring sudo privileges and network access.
+        - Modifies an SDDM system configuration file (`/etc/sddm.conf.d/kde_settings.conf`),
+          requiring sudo privileges.
+        - Logs failure messages if specific exceptions occur.
+
+    Raises:
+        TaskFailedException: If cloning the repository fails (e.g., Git not
+                             found, network error, repository access issues),
+                             if the SDDM configuration file is not found, or if
+                             any other unexpected exception occurs during the process.
+    """
     sddm_repo_name = "https://github.com/KJone1/sddm-dark-chocolate.git"
     clone_dest = "/usr/share/sddm/themes/sddm-dark-chocolate"
     sddm_config_file_path = "/etc/sddm.conf.d/kde_settings.conf"

--- a/pysible/modules/sudoers.py
+++ b/pysible/modules/sudoers.py
@@ -9,6 +9,31 @@ from pysible.utils.log_utils import Logger
 
 @task_plugin(name="Setup sudoers file", section=Sections.SYSTEM)
 def setup_sudoers():
+    """Validates and installs a custom sudoers configuration file.
+
+    This function performs the following steps:
+    1. Defines the source path of the custom sudoers file (from application
+       resources) and the destination path (`/etc/sudoers.d/kj`).
+    2. Validates the syntax of the source sudoers file using `visudo -c -f`.
+    3. If validation is successful, copies the source file to the system's
+       sudoers.d directory. This operation requires sudo privileges.
+    4. Logs the copy operation.
+
+    Side Effects:
+        - Runs `visudo` which checks sudoers file syntax.
+        - Copies a file to `/etc/sudoers.d/`, which modifies system
+          configuration and requires sudo privileges.
+        - Can alter user privileges on the system based on the content of the
+          copied sudoers file.
+        - Logs information about the process.
+
+    Raises:
+        TaskFailedException: If `visudo` validation fails (sh.ErrorReturnCode),
+                             if the source sudoers file is not found (FileNotFoundError),
+                             or if `copy_resource` fails (e.g., permission issues,
+                             though these are often caught as sh.ErrorReturnCode by
+                             the underlying sudo operation in copy_resource).
+    """
     sudoers_file_name = f"{settings.RESOURCES_DIR}/kj"
     sudoers_path = "/etc/sudoers.d/kj"
     try:

--- a/pysible/modules/tomb.py
+++ b/pysible/modules/tomb.py
@@ -11,6 +11,32 @@ from pysible.utils.net_utils import wget
 
 @task_plugin(name="Install Tomb", section=Sections.SOFTWARE, params={"version": "2.11"})
 def install_tomb(version: str):
+    """Installs Tomb, a tool for creating encrypted file storage.
+
+    This function downloads a specific version of Tomb from its GitHub
+    repository, extracts it, and then runs `make install` to install it
+    on the system.
+
+    Args:
+        version: The version string of Tomb to install (e.g., "2.11").
+                 This version is specified in the `@task_plugin` decorator's
+                 params and passed by the Pysible core.
+
+    Side Effects:
+        - Creates a temporary directory.
+        - Downloads a tarball from the internet.
+        - Extracts the tarball in the temporary directory.
+        - Runs `sudo make install`, which copies files to system locations
+          (e.g., /usr/local/bin, /usr/local/share/man) and requires sudo
+          privileges.
+        - Logs information about the process, including success or failure.
+
+    Raises:
+        TaskFailedException: If any step of the process fails, including
+                             download errors, extraction errors, `make install`
+                             returning a non-zero exit code (sh.ErrorReturnCode),
+                             or any other unexpected Python exception.
+    """
     tmp_dir_name = "tomb"
     tmp_dir_path = f"{settings.TMP_DIR}/{tmp_dir_name}"
     url = f"https://github.com/dyne/tomb/archive/refs/tags/v{version}.tar.gz"


### PR DESCRIPTION
This commit adds comprehensive docstrings to functions and methods in the following areas:

- All Python files within the `pysible/modules/` directory.
- `pysible/core/app.py` (also includes a typo fix for `_handle_user_input`).
- `pysible/core/task.py`.
- `pysible/core/task_manager.py`.

This work is part of a larger effort to improve code documentation, format the codebase, and identify potential improvements.

Further work will include adding docstrings to:
- `pysible/core/task_plugin_decorator.py`
- Files in `pysible/utils/`
- `main.py`

Following docstring additions, the codebase will be formatted, and a review for potential code improvements will be conducted.